### PR TITLE
Expire the correct tilt color

### DIFF
--- a/brewpi.py
+++ b/brewpi.py
@@ -1597,7 +1597,8 @@ def loop():  # Main program loop
                                 # Expire old Tiltbridge values
                                 if ((time.time() - lastTiltbridge) > timeoutTiltbridge) and tiltbridge == True:
                                     tiltbridge = False  # Turn off Tiltbridge in case we switched to BT
-                                    logMessage("Turned off Tiltbridge.")
+                                    color = config['tiltColor']
+                                    logMessage("Expired {} tilt and turned off Tiltbridge.".format(color))
                                     if checkKey(prevTempJson, color + 'Temp'):
                                         prevTempJson[color + 'Temp'] = None
                                     if checkKey(prevTempJson, color + 'SG'):

--- a/brewpi.py
+++ b/brewpi.py
@@ -1302,12 +1302,10 @@ def loop():  # Main program loop
 
                                                 # tilt.TILT_VERSIONS = ['Unknown', 'v1', 'v2', 'v3', 'Pro', 'v2 or 3']
 
-                                                if (checkKey(api['tilts'][config['tiltColor']], 'high_resolution')):
-                                                    if api['tilts'][config['tiltColor']]['high_resolution']:
-                                                        prevTempJson[config['tiltColor'] + 'HWVer'] = 4
-                                                elif (checkKey(api['tilts'][config['tiltColor']], 'sends_battery')):
-                                                    if api['tilts'][config['tiltColor']]['sends_battery']:
-                                                        prevTempJson[config['tiltColor'] + 'HWVer'] = 5 # Battery = >=2
+                                                if (checkKey(api['tilts'][config['tiltColor']], 'high_resolution') and api['tilts'][config['tiltColor']]['high_resolution']):
+                                                    prevTempJson[config['tiltColor'] + 'HWVer'] = 4
+                                                elif (checkKey(api['tilts'][config['tiltColor']], 'sends_battery') and api['tilts'][config['tiltColor']]['sends_battery']):
+                                                    prevTempJson[config['tiltColor'] + 'HWVer'] = 5 # Battery = >=2
                                                 else:
                                                     prevTempJson[config['tiltColor'] + 'HWVer'] = 0
 


### PR DESCRIPTION
When expiring a tilt, set color to the color in the config file first, otherwise we try and expire the last color in TILT_COLORS (Pink) which might not be the right color.
